### PR TITLE
Compatibility with go-imap v1 branch

### DIFF
--- a/mailbox.go
+++ b/mailbox.go
@@ -7,13 +7,13 @@ import (
 )
 
 type mailbox struct {
-	u *user
+	u    *user
 	name string
 	info *imap.MailboxInfo
 }
 
 func (m *mailbox) ensureSelected() error {
-	if m.u.c.Mailbox != nil && m.u.c.Mailbox.Name == m.name {
+	if selectedMbox := m.u.c.Mailbox(); selectedMbox != nil && selectedMbox.Name == m.name {
 		return nil
 	}
 
@@ -30,9 +30,8 @@ func (m *mailbox) Info() (*imap.MailboxInfo, error) {
 }
 
 func (m *mailbox) Status(items []string) (*imap.MailboxStatus, error) {
-	if m.u.c.Mailbox != nil && m.u.c.Mailbox.Name == m.name {
-		mbox := *m.u.c.Mailbox
-		return &mbox, nil
+	if selectedMailbox := m.u.c.Mailbox(); selectedMailbox != nil && selectedMailbox.Name == m.name {
+		return selectedMailbox, nil
 	}
 
 	return m.u.c.Status(m.name, items)


### PR DESCRIPTION
Add compatibility with the current state of the go-imap v1 branch

Note that go vet reported an issue with line 34: 
"assignment copies lock value to mbox: github.com/emersion/go-imap.MailboxStatus contains sync.Mutex".  I'm not sure if returning the original object, as opposed to a copy, is ok, but I did.

If there are tests that I should be running, please let me know?

Obviously, this is not intended to be a merge to master, but there is no existing v1 branch in go-imap-proxy
