### PR TITLE
Fixing Login() definition errors

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -3,7 +3,7 @@ package proxy
 import (
 	"crypto/tls"
 
-    "github.com/emersion/go-imap"
+	"github.com/emersion/go-imap"
 	"github.com/emersion/go-imap/backend"
 	"github.com/emersion/go-imap/client"
 )

--- a/backend.go
+++ b/backend.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"crypto/tls"
 
+    "github.com/emersion/go-imap"
 	"github.com/emersion/go-imap/backend"
 	"github.com/emersion/go-imap/client"
 )
@@ -64,7 +65,7 @@ func (be *Backend) login(username, password string) (*client.Client, error) {
 	return c, nil
 }
 
-func (be *Backend) Login(username, password string) (backend.User, error) {
+func (be *Backend) Login(_ *imap.ConnInfo,username, password string) (backend.User, error) {
 	c, err := be.login(username, password)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Compiling the example code right now results in a compilation error:

./main.go:14:17: cannot use be (type *proxy.Backend) as type backend.Backend in argument to server.New:
	*proxy.Backend does not implement backend.Backend (wrong type for Login method)
		have Login(string, string) (backend.User, error)
		want Login(*imap.ConnInfo, string, string) (backend.User, error)

This pull request fixes it.